### PR TITLE
[codex] Use aqua-managed golangci-lint in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,5 +36,10 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
 
+      - name: Set up aqua
+        uses: aquaproj/aqua-installer@11dd79b4e498d471a9385aa9fb7f62bb5f52a73c # v4.0.4
+        with:
+          aqua_version: v2.57.2
+
       - name: Run golangci-lint
-        run: go tool golangci-lint run 
+        run: golangci-lint run


### PR DESCRIPTION
## Summary

- Add `aquaproj/aqua-installer` to the lint job.
- Run `golangci-lint` from aqua instead of `go tool golangci-lint`.

## Why

`golangci-lint` is already listed in `aqua.yaml`, so CI should use the same managed tool version rather than a separate Go tool invocation.

## Validation

- `actionlint`