### PR TITLE
[codex] Update golangci-lint to v2

### DIFF
--- a/aqua.yaml
+++ b/aqua.yaml
@@ -12,6 +12,6 @@ registries:
     ref: v4.519.0 # renovate: depName=aquaproj/aqua-registry
 packages:
   - name: evilmartians/lefthook@v2.1.9
-  - name: golangci/golangci-lint@v1.64.8
+  - name: golangci/golangci-lint@v2.12.2
   - name: suzuki-shunsuke/pinact@v4.0.0
   - name: zizmorcore/zizmor@v1.25.2

--- a/interceptor.go
+++ b/interceptor.go
@@ -168,7 +168,7 @@ func (cmi *ContentModifierInterceptor) ProcessResponse(resp *http.Response, req 
 			cmi.logger.Error("Failed to read response body", "error", err)
 			return resp, err
 		}
-		resp.Body.Close()
+		_ = resp.Body.Close()
 
 		// Convert body content to string
 		bodyStr := string(bodyBytes)

--- a/interceptor_test.go
+++ b/interceptor_test.go
@@ -347,7 +347,9 @@ func TestInterceptorChain(t *testing.T) {
 	// Send request
 	resp, err := client.Do(req)
 	require.NoError(t, err, "Should be able to send request")
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	// No need to verify request headers here as they are checked at the target server
 
@@ -409,7 +411,9 @@ func TestFilteringInterceptorBlock(t *testing.T) {
 	// Send request
 	resp, err := client.Do(req)
 	require.NoError(t, err, "Should be able to send request")
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	// Verify response status code
 	assert.Equal(t, http.StatusForbidden, resp.StatusCode, "Response status code should be 403 Forbidden")

--- a/mitmproxxy.go
+++ b/mitmproxxy.go
@@ -78,7 +78,9 @@ func (mp *ServerMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			mp.handleError(w, err)
 			return
 		}
-		defer con.Close()
+		defer func() {
+			_ = con.Close()
+		}()
 
 		if err := mp.handleConnect(con, r); err != nil {
 			mp.handleConnectError(con, err)
@@ -120,7 +122,9 @@ func (mp *ServerMux) handleConnect(con net.Conn, r *http.Request) error {
 	if err != nil {
 		return err
 	}
-	defer tlsConn.Close()
+	defer func() {
+		_ = tlsConn.Close()
+	}()
 
 	// Set TLS connection timeout
 	if err := tlsConn.SetDeadline(time.Now().Add(mp.readTimeout)); err != nil {
@@ -154,7 +158,9 @@ func (mp *ServerMux) handleNonConnect(w http.ResponseWriter, r *http.Request) er
 
 	// Make sure to close the request body if it exists
 	if r.Body != nil {
-		defer r.Body.Close()
+		defer func() {
+			_ = r.Body.Close()
+		}()
 	}
 
 	var skipRemaining bool
@@ -186,7 +192,9 @@ func (mp *ServerMux) handleNonConnect(w http.ResponseWriter, r *http.Request) er
 		errorType := determineErrorType(err)
 		return NewProxyError(errorType, "do_request", "failed to send request", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	// Response interception processing
 	for _, interceptor := range mp.interceptors {
@@ -226,7 +234,9 @@ func (mp *ServerMux) writeConnectionEstablished(con net.Conn) error {
 func (mp *ServerMux) forwardRequest(conn net.Conn, req *http.Request) error {
 	// Make sure to close the request body if it exists
 	if req.Body != nil {
-		defer req.Body.Close()
+		defer func() {
+			_ = req.Body.Close()
+		}()
 	}
 
 	var err error
@@ -251,7 +261,9 @@ func (mp *ServerMux) forwardRequest(conn net.Conn, req *http.Request) error {
 		errorType := determineErrorType(err)
 		return NewProxyError(errorType, "do_request", "failed to send request", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	// Response interception processing
 	for _, interceptor := range mp.interceptors {
@@ -455,7 +467,9 @@ func (mp *ServerMux) handleError(w http.ResponseWriter, err error) {
 
 		if hijacker, ok := w.(http.Hijacker); ok {
 			if conn, _, err := hijacker.Hijack(); err == nil {
-				defer conn.Close()
+				defer func() {
+					_ = conn.Close()
+				}()
 				resp := &http.Response{
 					StatusCode: statusCode,
 					Status:     http.StatusText(statusCode),
@@ -561,7 +575,7 @@ func (c *InspectingHTTPClient) Do(req *http.Request) (*http.Response, error) {
 		if err != nil {
 			return nil, err
 		}
-		resp.Body.Close()
+		_ = resp.Body.Close()
 
 		// Record the body
 		c.BodyLog = append(c.BodyLog, string(body))

--- a/mitmproxxy_test.go
+++ b/mitmproxxy_test.go
@@ -209,7 +209,9 @@ func TestMitmProxy_Handler(t *testing.T) {
 	// Send request
 	resp, err := client.Get(requestURL.String())
 	require.NoError(t, err, "Should be able to send request")
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	// Ensure interceptor was called
 	assert.True(t, requestReceived, "Request interceptor should be called")
@@ -307,7 +309,9 @@ func TestMitmProxy_Connected(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to send request: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	// Ensure response status is correct
 	if resp.StatusCode != http.StatusOK {
@@ -363,7 +367,9 @@ func TestServerMux_ServeHTTP_NonConnect(t *testing.T) {
 
 		resp, err := client.Do(req)
 		require.NoError(t, err, "Should be able to send request")
-		defer resp.Body.Close()
+		defer func() {
+			_ = resp.Body.Close()
+		}()
 
 		// Verify response
 		assert.Equal(t, http.StatusOK, resp.StatusCode, "Should return OK status")
@@ -381,7 +387,9 @@ func TestServerMux_ServeHTTP_NonConnect(t *testing.T) {
 		resp, err := client.Do(req)
 		// The proxy should return an error response, not fail the request entirely
 		require.NoError(t, err, "Should be able to send request")
-		defer resp.Body.Close()
+		defer func() {
+			_ = resp.Body.Close()
+		}()
 
 		// The proxy returns 502 when it can't resolve the hostname
 		assert.Equal(t, http.StatusBadGateway, resp.StatusCode, "Should return 502 for unresolvable hostnames")
@@ -395,7 +403,9 @@ func TestServerMux_ServeHTTP_NonConnect(t *testing.T) {
 
 		resp, err := client.Do(req)
 		require.NoError(t, err, "Should be able to send request")
-		defer resp.Body.Close()
+		defer func() {
+			_ = resp.Body.Close()
+		}()
 
 		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode, "Should return 500 for invalid scheme requests")
 	})
@@ -494,7 +504,9 @@ func TestMitmProxy_WithInterceptors(t *testing.T) {
 	// Send request
 	resp, err := client.Do(req)
 	require.NoError(t, err, "Should be able to send request")
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	// No need to verify request headers here as they are checked at the target server
 	// Verify response headers
@@ -813,7 +825,9 @@ func TestMitmProxy_InspectTLSTraffic(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to send request through proxy: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	// Read response body
 	body, err := io.ReadAll(resp.Body)
@@ -1000,7 +1014,9 @@ func TestNew(t *testing.T) {
 		// Create a test file with invalid certificate format
 		tempFile, err := os.CreateTemp("", "invalid-cert-*.crt")
 		require.NoError(t, err, "Should be able to create temp file")
-		defer os.Remove(tempFile.Name())
+		defer func() {
+			_ = os.Remove(tempFile.Name())
+		}()
 
 		_, err = tempFile.WriteString("THIS IS NOT A VALID CERTIFICATE")
 		require.NoError(t, err, "Should be able to write to temp file")


### PR DESCRIPTION
## Summary

This is a separate PR from Renovate PR #22. It applies the same golangci-lint major version update independently and includes the CI lint fixes needed for v2.

- update `golangci/golangci-lint` in `aqua.yaml` from `v1.64.8` to `v2.12.2`
- make ignored `Close` / `Remove` errors explicit with `_ = ...` so `errcheck` passes under golangci-lint v2
- keep the existing aqua/pinact/zizmor/GitHub Actions hardening setup unchanged

## Verification

- `go test -v -race ./...`
- `aqua exec -- golangci-lint run`